### PR TITLE
fix: Install link is broken

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Lets you see each stage of the transform process for a TypeScript JS + DTS emit 
 
 ## Running this plugin
 
-- [Click this link](https://typescriptlang.org/play?install-plugin=playground-transformer-timeline) to install
+- [Click this link](https://www.typescriptlang.org/play?install-plugin=playground-transformer-timeline) to install
 
 or
 


### PR DESCRIPTION
The TS site doesn't correctly redirect https traffic incoming without the `www` subdomain, so clicking the install link doesn't work.