### PR TITLE
Use getTypeChecker API to fix transformers plugin

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -32,8 +32,7 @@ const makePlugin = (utils: PluginUtils) => {
 
         const program = await sandbox.createTSProgram();
 
-        // @ts-expect-error - private API
-        let checker: TypeChecker = program.getDiagnosticsProducingTypeChecker();
+        let checker: TypeChecker = program.getTypeChecker();
         let sourceFile = program.getSourceFile(sandbox.filepath);
         let options = sandbox.getCompilerOptions();
 


### PR DESCRIPTION
Hey! 

I noticed that the transformers plugin isn't working (related issue: https://github.com/orta/playground-transformer-timeline/issues/7) due to missing `getDiagnosticsProducingTypeChecker` API:

<img width="913" alt="CleanShot 2023-02-24 at 15 54 24@2x" src="https://user-images.githubusercontent.com/9019397/221209588-8caa063d-4c16-4697-b018-80ab882b1940.png">

I played a bit with the plugin locally and got it working properly by using `getTypeChecker` instead. Let me know if that's not the correct approach. 

